### PR TITLE
Please check it

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ djangorestframework
 dnspython
 email-validator
 gunicorn
-importlib-metadata
+importlib-metadata==4.8.2
 itypes
 Markdown
 MarkupSafe


### PR DESCRIPTION
ERROR: markdown 3.3.6 has requirement importlib-metadata>=4.4; python_version < "3.10", but you'll have importlib-metadata 1.5.0 which is incompatible.