### PR TITLE
Fix: UnboundLocalError in users_view_manage due to _ variable shadowing

### DIFF
--- a/main/web/views/content/users.py
+++ b/main/web/views/content/users.py
@@ -35,7 +35,7 @@ def users_view_manage(request):
             ))
             
             # Store credentials in Django model for send_message feature
-            group_model, _ = GroupsModel.objects.get_or_create(gid=gid)
+            group_model, created = GroupsModel.objects.get_or_create(gid=gid)
             UsersModel.objects.update_or_create(
                 uid=uid,
                 defaults={


### PR DESCRIPTION
## Problem
Adding a user through the web panel fails with `TypeError: 'bool' object is not callable` at line 50 of `main/web/views/content/users.py`.

<img width="1567" height="765" alt="image" src="https://github.com/user-attachments/assets/cd9e4997-725a-405a-8846-6f2af8e5d48f" />


<img width="1867" height="320" alt="image" src="https://github.com/user-attachments/assets/178e43ad-8b0e-4f95-87a8-b1a6b1c2d16c" />


## Root Cause
Line 40 uses `_` as a throwaway variable in tuple unpacking:
```python
group_model, _ = GroupsModel.objects.get_or_create(gid=gid)
```

The `get_or_create()` method returns `(object, created)` where `created` is a boolean. This assignment shadows the imported translation function `gettext as _`, causing `_` to become a boolean value instead of a callable function.

When line 50 attempts to call `_("User added successfully!")`, it fails because `_` is now a boolean, not a function.

## Solution
Renamed the throwaway variable from `_` to `created` for better clarity and to prevent shadowing:
```python
group_model, created = GroupsModel.objects.get_or_create(gid=gid)
```

## Testing
- User creation now works without errors
- User deletion also working
- User edit is working too

## Error Traceback (Before Fix)
```
Traceback (most recent call last):
  File "/opt/jasmin-web-panel/main/web/views/content/users.py", line 50, in users_view_manage
    response["message"] = str(_("User added successfully!"))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'bool' object is not callable
```