### PR TITLE
Add Celery worker systemd service documentation for manual installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,34 @@ RestartSec=10
 WantedBy=multi-user.target
 ```
 
+### Create Celery Worker Service
+
+The web panel requires a Celery worker to process background tasks like report exports from Submit Logs Page.
+
+Create `/etc/systemd/system/jasmin-web-panel-celery.service`:
+
+```ini
+[Unit]
+Description=Jasmin Web Panel Celery Worker
+After=network.target redis.service
+Requires=redis.service
+
+[Service]
+Type=simple
+SyslogIdentifier=jasmin-web-panel-celery
+User=www-data
+Group=www-data
+WorkingDirectory=/opt/jasmin-web-panel
+Environment="DJANGO_SETTINGS_MODULE=config.settings.pro"
+Environment="CELERY_LOG_LEVEL=info"
+ExecStart=/opt/jasmin-web-panel/env/bin/celery --app config worker --max-tasks-per-child 1 -l info
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+```
+
 #### 2. Enable and Start Service
 
 ```bash
@@ -356,6 +384,14 @@ sudo systemctl enable jasmin-web.service
 sudo systemctl start jasmin-web.service
 sudo systemctl status jasmin-web.service
 ```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable jasmin-web-panel-celery.service
+sudo systemctl start jasmin-web-panel-celery.service
+sudo systemctl status jasmin-web-panel-celery.service
+```
+
 
 #### 3. Configure Nginx
 


### PR DESCRIPTION
## Description
Added documentation for setting up the Celery worker systemd service during manual installation.

## Problem
The manual installation guide was missing the Celery worker service setup.
Export feature was calling Celery tasks, but no Celery worker was running for the web panel
The existing jasmin-celery service was only for SMS gateway tasks, not web panel tasks.

Task ID Created:
<img width="1916" height="622" alt="image" src="https://github.com/user-attachments/assets/52879386-4842-4635-91a9-d48f06a96fed" />

But not found:
<img width="1918" height="586" alt="image" src="https://github.com/user-attachments/assets/d9c0c751-ada9-4a3c-99c0-fb4fdf22407e" />

<img width="935" height="206" alt="image" src="https://github.com/user-attachments/assets/c58b4ac9-02a4-4257-8410-cec1087f35f4" />

## Solution
- Added systemd service configuration for `jasmin-web-panel-celery`
- Added commands to enable and start the service
- Service configuration matches the Docker setup using `--max-tasks-per-child 1`

<img width="1865" height="653" alt="image" src="https://github.com/user-attachments/assets/b19b5996-0ab3-419b-9ea3-46de66a17f73" />

<img width="1918" height="691" alt="image" src="https://github.com/user-attachments/assets/c48347e3-3c88-465e-9832-a561ce568c3b" />

## Testing
Tested on Ubuntu 24.04 with manual installation:
- export functionality now working